### PR TITLE
Update http-server 0.8.5 -> 0.9.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -32,7 +32,7 @@
     "cross-env": "^1.0.5",
     "eslint": "^1.10.3",
     "eslint-plugin-html": "^1.1.0",
-    "http-server": "^0.8.5",
+    "http-server": "^0.9.0",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.15",
     "karma-browserify": "^4.4.2",


### PR DESCRIPTION
http-server throws error `The header content contains invalid characters` on Windows.
https://github.com/indexzero/http-server/issues/244

Update http-server to solve the problem.