### PR TITLE
fix babel-runtime dependency to 6.0.0 version

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",
-    "babel-runtime": "^5.8.0",
+    "babel-runtime": "^6.0.0",
     "babelify": "^7.2.0",
     "browserify": "^12.0.1",
     "browserify-hmr": "^0.3.1",


### PR DESCRIPTION
npm install fails due to 'vueify@8.4.1 wants babel-runtime@^6.0.0'