### PR TITLE
Add select option to init process: Standalone or runtime-only? (solve #12)

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -18,6 +18,22 @@
     "private": {
       "type": "boolean",
       "default": true
-    }
+    },
+    "build": {
+      "type": "list",
+      "Message": "Vue comes in two build versions, which do you want to use?",
+      "choices": [
+        {
+          "name": "Runtime-only: lighter, but no support for templates defined in .html files (.vue files are fine)",
+          "value": "runtime",
+          "short": "tuntime"
+        },
+        {
+          "name": "Standalone: heavier, because it includes the template parser to allow template in .html files",
+          "value": "standalone",
+          "short": "standalone"
+        }
+      ]
+    },
   }
 }

--- a/meta.json
+++ b/meta.json
@@ -29,7 +29,7 @@
           "short": "tuntime"
         },
         {
-          "name": "Standalone: heavier, because it includes the template parser to allow template in .html files",
+          "name": "Standalone: heavier, because it includes the template parser to allow templates in .html files",
           "value": "standalone",
           "short": "standalone"
         }

--- a/meta.json
+++ b/meta.json
@@ -34,6 +34,6 @@
           "short": "standalone"
         }
       ]
-    },
+    }
   }
 }

--- a/meta.json
+++ b/meta.json
@@ -21,7 +21,7 @@
     },
     "build": {
       "type": "list",
-      "Message": "Vue comes in two build versions, which do you want to use?",
+      "message": "Vue comes in two build versions, which do you want to use?",
       "choices": [
         {
           "name": "Runtime-only: lighter, but no support for templates defined in .html files (.vue files are fine)",

--- a/template/package.json
+++ b/template/package.json
@@ -19,10 +19,20 @@
       "babelify"
     ]
   },
+  {{#if_eq build "standalone"}}
+  "aliasify": {
+    "aliases": {
+      "vue": "vue/dist/vue"
+    }
+  },
+  {{/if_eq}}
   "dependencies": {
     "vue": "^2.0.0-rc.1"
   },
   "devDependencies": {
+    {{#if_eq build "standalone"}}
+    "aliasify": "^2.0.0",
+    {{/if_eq}}
     "babel-core": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -2,7 +2,7 @@
 // The following line loads the standalone build of Vue instead of the runtime-only build,
 // so you don't have to do: import Vue from 'vue/dist/vue'
 // (also, loading Vue standalone this way breaks vueify, so don't do it)
-// This is done with the traonsform "aliasify". For the config, see package.json
+// This is done with the transform "aliasify". For the config, see package.json
 {{/if_eq}}
 import Vue from 'vue'
 import App from './App.vue'

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,3 +1,9 @@
+{{#if_eq build "standalone"}}
+// The following line loads the standalone build of Vue instead of the runtime-only build,
+// so you don't have to do: import Vue from 'vue/dist/vue'
+// (also, loading Vue standalone this way breaks vueify, so don't do it)
+// This is done with the traonsform "aliasify". For the config, see package.json
+{{/if_eq}}
 import Vue from 'vue'
 import App from './App.vue'
 


### PR DESCRIPTION
Solves #12

User can select between the two build versions:
* runtime-only
* standalone

![bildschirmfoto 2016-09-11 um 21 25 16](https://cloud.githubusercontent.com/assets/1444526/18419915/4f959e88-7866-11e6-9437-1ea9cbb9d793.png)

* If "runtime-only" is selected, nothing happens as this is the default import
* If "standalone" is selected, we add an alias to the webpack conf and a comment in main.js informing the user about this.