### PR TITLE
Default dns doesn't work on docker

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
   {{/private}}
   "scripts": {
     "watchify": "watchify -vd -p browserify-hmr -e src/main.js -o dist/build.js",
-    "serve": "http-server -o -c 1 -a localhost",
+    "serve": "http-server -o -c 1",
     "dev": "npm-run-all --parallel watchify serve",
     {{#lint}}
     "lint": "eslint --ext .js,.vue src{{#unit}} test/unit{{/unit}}",


### PR DESCRIPTION
Removed option "-a localhost", because this dns isn't recognized by
docker

Removing this option makes http-server defaults to 127.0.0.1

https://github.com/vuejs/vue-cli/issues/36