### PR TITLE
Fix aliasing with aliasify

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,6 +17,9 @@
   },
   "browserify": {
     "transform": [
+      {{#if_eq build "standalone"}}
+      "aliasify",
+      {{/if_eq}}
       "vueify",
       "babelify"
     ]
@@ -24,7 +27,7 @@
   {{#if_eq build "standalone"}}
   "aliasify": {
     "aliases": {
-      "vue": "vue/dist/vue"
+      "vue$": "vue/dist/vue"
     }
   },
   {{/if_eq}}

--- a/template/package.json
+++ b/template/package.json
@@ -17,11 +17,11 @@
   },
   "browserify": {
     "transform": [
+      "babelify",
       {{#if_eq build "standalone"}}
       "aliasify",
       {{/if_eq}}
-      "vueify",
-      "babelify"
+      "vueify"
     ]
   },
   {{#if_eq build "standalone"}}


### PR DESCRIPTION
- [x] Properly alias Vue: by aliasing `vue$`, other imports from the vue package still work
- [x] add missing aliasify transform (conditionally, when stndalone build is selected). Important: move it before vueify, but after babelify. Order matters!