### PR TITLE
standalone version breaks due to some bug of aliasify (fix #26)

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -17,17 +17,17 @@
     },
     "build": {
       "type": "list",
-      "message": "Vue comes in two build versions, which do you want to use?",
+      "message": "Vue build",
       "choices": [
         {
-          "name": "Runtime-only: lighter, but no support for templates defined in .html files (.vue files are fine)",
-          "value": "runtime",
-          "short": "runtime"
-        },
-        {
-          "name": "Standalone: heavier, because it includes the template parser to allow templates in .html files",
+          "name": "Runtime + Compiler: recommended for most users",
           "value": "standalone",
           "short": "standalone"
+        },
+        {
+          "name": "Runtime-only: about 6KB lighter min+gzip, but templates (or any Vue-specific HTML) are ONLY allowed in .vue files - render functions are required elsewhere",
+          "value": "runtime",
+          "short": "runtime"
         }
       ]
     },

--- a/template/package.json
+++ b/template/package.json
@@ -18,26 +18,18 @@
   "browserify": {
     "transform": [
       "babelify",
-      {{#if_eq build "standalone"}}
-      "aliasify",
-      {{/if_eq}}
       "vueify"
     ]
   },
   {{#if_eq build "standalone"}}
-  "aliasify": {
-    "aliases": {
-      "vue$": "vue/dist/vue"
-    }
+  "browser": {
+    "vue": "vue/dist/vue"
   },
   {{/if_eq}}
   "dependencies": {
     "vue": "^2.0.1"
   },
   "devDependencies": {
-    {{#if_eq build "standalone"}}
-    "aliasify": "^2.0.0",
-    {{/if_eq}}
     "babel-core": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,8 +1,7 @@
 {{#if_eq build "standalone"}}
 // The following line loads the standalone build of Vue instead of the runtime-only build,
 // so you don't have to do: import Vue from 'vue/dist/vue'
-// (also, loading Vue standalone this way breaks vueify, so don't do it)
-// This is done with the transform "aliasify". For the config, see package.json
+// This is done with the browser options. For the config, see package.json
 {{/if_eq}}
 import Vue from 'vue'
 import App from './App.vue'


### PR DESCRIPTION
1. keep build info update with webpack template version
2. use browser option instead of aliasify

fix #26  and https://github.com/vuejs/vue/issues/3965