### PR TITLE
Remove the 'name' attribute from the .vue component definitions.

### DIFF
--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -8,7 +8,6 @@
 import Hello from './components/Hello.vue'
 
 export default {
-  name: 'app',
   components: {
     Hello
   }

--- a/template/src/components/Hello.vue
+++ b/template/src/components/Hello.vue
@@ -21,7 +21,6 @@
 
 <script>
 export default {
-  name: 'hello',
   data () {
     return {
       msg: 'Welcome to Your Vue.js App'


### PR DESCRIPTION
Usage of the 'name' attribute is misleading. When used from a single-file
component, the component's name is generated based on the filename.

Example:
Goal: Modify the basic example to use the component <hello-world>.

Renaming the 'name' of e.g. App.vue or Hello.vue has no effect (afaict).
Removing the 'name' attribute has no effect.
Renaming the actual file name to HelloWorld.vue does the expected.