### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ $ npm install -g vue-cli
 $ vue init browserify my-project
 $ cd my-project
 $ npm install
+$ npm build
 $ npm run dev
 ```
 


### PR DESCRIPTION
Without the build step, the page served with `npm run dev` is empty (and displays a 404 in the console).