### PR TITLE
Update meta.json

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -48,8 +48,7 @@
   },
   "filters": {
     ".eslintrc.js": "lint",
-    "test/unit/**/*": "unit",
-    "test/e2e/**/*": "e2e"
+    "test/unit/**/*": "unit"
   },
   "completeMessage": "To get started:\n\n  cd {{destDirName}}\n  npm install\n  npm run dev"
 }


### PR DESCRIPTION
Removed filter for e2e tests

**Reasons**
- Consistency.
- Template does not include e2e tests, at this time.
- Eliminates the need to filter for inexistent directories should we ever need to iterate those.